### PR TITLE
Add 'format_options' option

### DIFF
--- a/lib/Plack/Middleware/AxsLog.pm
+++ b/lib/Plack/Middleware/AxsLog.pm
@@ -6,7 +6,7 @@ use 5.8.5;
 use parent qw/Plack::Middleware/;
 use Plack::Util;
 use Time::HiRes qw/gettimeofday/;
-use Plack::Util::Accessor qw/response_time combined ltsv format compiled_format error_only long_response_time logger/;
+use Plack::Util::Accessor qw/response_time combined ltsv format format_options compiled_format error_only long_response_time logger/;
 use POSIX qw//;
 use Time::Local qw//;
 use HTTP::Status qw//;
@@ -21,9 +21,10 @@ sub prepare_app {
     $self->error_only(0) if ! defined $self->error_only;
     $self->long_response_time(0) if ! defined $self->long_response_time;
 
-    my $format;
+    my ($format, %format_options);
     if ( $self->format ) {
         $format = $self->format;
+        %format_options = %{ $self->format_options } if $self->format_options;
     }
     elsif ( $self->ltsv ) {
         $format = join "\t",
@@ -39,7 +40,7 @@ sub prepare_app {
         $format .= ' %D' if $self->response_time;
     }
 
-    $self->compiled_format(Apache::LogFormat::Compiler->new($format));
+    $self->compiled_format(Apache::LogFormat::Compiler->new($format, %format_options));
 }
 
 sub call {

--- a/t/05_format_options.t
+++ b/t/05_format_options.t
@@ -1,0 +1,36 @@
+use strict;
+use warnings;
+use HTTP::Request::Common;
+use HTTP::Message::PSGI;
+use Plack::Builder;
+use Plack::Test;
+use Test::More;
+
+{
+    my $log = '';
+    my $app = builder {
+        enable 'AxsLog', 
+            format => '%z %{X_MYAPP_VARIABLE}Z', 
+            format_options => +{
+                char_handlers => +{
+                    'z' => sub { 'z' },
+                },
+                block_handlers => +{
+                    'Z' => sub { 'Z' },
+                },
+            },
+            logger => sub { $log .= $_[0] };
+        sub{ [ 200, [], [ "Hello "] ] };
+    };
+    test_psgi
+        app => $app,
+        client => sub {
+            my $cb = shift;
+            my $res = $cb->(GET "/");
+            chomp $log;
+            like $log, qr!z Z!;
+        };
+}
+
+done_testing();
+


### PR DESCRIPTION
I'd like to use ALFC's char_handlers and block_handlers options with this middleware.
Currently there are no path to pass these options to underlying ALFC,
so I added 'format_options' to AxsLog's options.

One alternative interface might be:

enable 'AxsLog',
    format => ...
    char_handlers => ...
    blchar_handlers => ...

I am not sure which is the better.
